### PR TITLE
Fix tests when running with musl

### DIFF
--- a/tests/libtest-core.sh
+++ b/tests/libtest-core.sh
@@ -37,9 +37,15 @@ assert_not_reached () {
 # Some tests look for specific English strings. Use a UTF-8 version
 # of the C (POSIX) locale if we have one, or fall back to en_US.UTF-8
 # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8)
-export LC_ALL=$(locale -a | grep -Ee '\.(UTF-8|utf8)' | grep -iEe '^(C|en_US)' | head -1 || true)
-if [ -z "${LC_ALL}" ]; then fatal "Can't find suitable UTF-8 locale"; fi
-
+#
+# If we can't find the locale command assume we have support for C.UTF-8
+# (e.g. musl based systems)
+if type -p locale >/dev/null; then
+    export LC_ALL=$(locale -a | grep -Ee '\.(UTF-8|utf8)' | grep -iEe '^(C|en_US)' | head -1 || true)
+    if [ -z "${LC_ALL}" ]; then fatal "Can't find suitable UTF-8 locale"; fi
+else
+    export LC_ALL=C.UTF-8
+fi
 # A GNU extension, used whenever LC_ALL is not C
 unset LANGUAGE
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -440,7 +440,9 @@ EOF
     ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --add-metadata-string version=1.0.10 -b testos/buildmaster/x86_64-runtime -s "Build"
 
     cd ${test_tmpdir}
-    cp -a osdata osdata-devel
+    rm -rf osdata-devel
+    mkdir osdata-devel
+    tar -C osdata -cf - . | tar -C osdata-devel -xf -
     cd osdata-devel
     mkdir -p usr/include
     echo "a development header" > usr/include/foo.h

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -177,7 +177,7 @@ if ! skip_one_without_user_xattrs; then
     ${CMD_PREFIX} ostree --repo=cacherepo pull-local ostree-srv/gnomerepo main
     rev=$(ostree --repo=cacherepo rev-parse main)
     ${CMD_PREFIX} ostree --repo=cacherepo ls -R -C main > ls.txt
-    regfile_hash=$(grep -E -e '^-0' ls.txt | head -1 | awk '{ print $5 }')
+    regfile_hash=$((grep -E -e '^-0' ls.txt || true) | head -1 | awk '{ print $5 }')
     ${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false corruptrepo $(cat httpd-address)/ostree/corruptrepo
     # Make this a loop so in the future we can add more object types like commit etc.
     for object in ${regfile_hash}.file; do

--- a/tests/test-admin-gpg.sh
+++ b/tests/test-admin-gpg.sh
@@ -90,7 +90,9 @@ EOF
     ${CMD_PREFIX} ostree --repo=${test_tmpdir}/testos-repo commit --add-metadata-string version=1.0.10 -b testos/buildmaster/x86_64-runtime -s "Build" --gpg-sign=$keyid --gpg-homedir=${test_tmpdir}/gpghome
 
     cd ${test_tmpdir}
-    cp -a osdata osdata-devel
+    rm -rf osdata-devel
+    mkdir osdata-devel
+    tar -C osdata -cf - . | tar -C osdata-devel -xf -
     cd osdata-devel
     mkdir -p usr/include
     echo "a development header" > usr/include/foo.h

--- a/tests/test-pull-mirrorlist.sh
+++ b/tests/test-pull-mirrorlist.sh
@@ -47,12 +47,12 @@ setup_mirror content_mirror3
 
 # Let's delete a file from 1 so that it falls back on 2
 cd ${test_tmpdir}/content_mirror1/ostree/gnomerepo
-filez=$(find objects/ -name '*.filez' | head -n 1)
+filez=$((find objects/ -name '*.filez' || true) | head -n 1)
 rm ${filez}
 
 # Let's delete a file from 1 and 2 so that it falls back on 3
 cd ${test_tmpdir}/content_mirror1/ostree/gnomerepo
-filez=$(find objects/ -name '*.filez' | head -n 1)
+filez=$((find objects/ -name '*.filez' || true) | head -n 1)
 rm ${filez}
 cd ${test_tmpdir}/content_mirror2/ostree/gnomerepo
 rm ${filez}


### PR DESCRIPTION
When running under musl rather than glibc, the tests fail because of minor differences. There's three commits here, the first is straightforward (handle EPIPE), the second is possibly more contentious (default to C.UTF-8 as the locale command doesn't exist), the third looks like a problem somewhere between coreutils and musl and this is simply a workaround for someone elses problem.